### PR TITLE
create_payloads beefed up and tests passing

### DIFF
--- a/test/models/payload_request_test.rb
+++ b/test/models/payload_request_test.rb
@@ -38,14 +38,13 @@ class PayloadRequestTest < Minitest::Spec
     assert_equal "63.29.38.211", payload.ip
   end
 
-
-    def test_duplicate_urls_pass_existing_id_to_payload
-      assert_equal 3, PayloadRequest.all.map { |payload| payload.url_id }.uniq.count
-      assert_equal 4, PayloadRequest.all.count
-    end
+  def test_duplicate_urls_pass_existing_id_to_payload
+    assert_equal 3, PayloadRequest.all.map { |payload| payload.url_id }.uniq.count
+    assert_equal 15, PayloadRequest.all.count
+  end
 
   def test_it_calculates_average_response_time
-    assert_equal 66.0, PayloadRequest.average_response_time.to_f
+    assert_equal 55.53, PayloadRequest.average_response_time.to_f.round(2)
   end
 
   def test_it_calculates_maximum_response_time
@@ -55,7 +54,7 @@ class PayloadRequestTest < Minitest::Spec
 
   def test_it_calculates_minimum_response_time
 
-    assert_equal 37, PayloadRequest.minimum_response_time
+    assert_equal 10, PayloadRequest.minimum_response_time
   end
 
   def test_it_lists_events_in_order_of_frequency

--- a/test/models/request_type_test.rb
+++ b/test/models/request_type_test.rb
@@ -12,7 +12,8 @@ class DisplayTest < Minitest::Spec
     assert all_verbs.any? { |verb| verb == "GET" }
     assert all_verbs.any? { |verb| verb == "POST" }
     assert all_verbs.any? { |verb| verb == "DELETE" }
-    assert_equal 3, all_verbs.count
+    assert all_verbs.any? { |verb| verb == "PUT" }
+    assert_equal 4, all_verbs.count
   end
 
   def test_request_type_knows_most_frequent_request_type

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -28,134 +28,34 @@ class UrlTest < Minitest::Spec
   end
 
   def test_returns_min_response_time_by_url
-    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://turing.io/").id,
-                            requested_at: "2014-02-16 21:38:28 -0700",
-                            responded_in: 10,
-                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
-                            request_type_id: RequestType.find_or_create_by(verb: "POST").id,
-                            event_name: "passwordEntry",
-                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Opera/24.0.1309.0 Safari/537.17").browser,
-                                                 os: UserAgent.parse("Mozilla/5.0 (Linux; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
-                                                 ).id,
-                            display_id: Display.find_or_create_by(width: "9000", height: "9000").id,
-                            ip: "99.99.99.9999"
-                          })
 
     url = Url.find_by(address: "http://turing.io/")
     assert_equal 10, Url.min_response_time(url)
   end
 
   def test_can_list_ordered_response_times_by_url
-    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://turing.io/").id,
-                            requested_at: "2014-02-16 21:38:28 -0700",
-                            responded_in: 100,
-                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
-                            request_type_id: RequestType.find_or_create_by(verb: "POST").id,
-                            event_name: "passwordEntry",
-                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Opera/24.0.1309.0 Safari/537.17").browser,
-                                                 os: UserAgent.parse("Mozilla/5.0 (Linux; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
-                                                 ).id,
-                            display_id: Display.find_or_create_by(width: "9000", height: "9000").id,
-                            ip: "99.99.99.9999"
-                          })
 
     url = Url.find_by(address: "http://turing.io/")
 
     sorted_response_times = Url.sorted_response_times(url)
 
-    assert_equal [100, 90], sorted_response_times
+    assert_equal [100, 100, 100, 90, 10], sorted_response_times
   end
 
   def test_can_find_avg_for_all_response_times_by_url
-    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://turing.io/").id,
-                            requested_at: "2014-02-16 21:38:28 -0700",
-                            responded_in: 100,
-                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
-                            request_type_id: RequestType.find_or_create_by(verb: "POST").id,
-                            event_name: "passwordEntry",
-                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Opera/24.0.1309.0 Safari/537.17").browser,
-                                                 os: UserAgent.parse("Mozilla/5.0 (Linux; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
-                                                 ).id,
-                            display_id: Display.find_or_create_by(width: "9000", height: "9000").id,
-                            ip: "99.99.99.9999"
-                          })
 
     url = Url.find_by(address: "http://turing.io/")
 
-    assert_equal 95, Url.average_response_time(url)
+    assert_equal 80.0, Url.average_response_time(url).to_f
   end
 
   def test_can_find_http_verbs_by_url
-    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://turing.io/").id,
-                            requested_at: "2014-02-16 21:38:28 -0700",
-                            responded_in: 100,
-                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
-                            request_type_id: RequestType.find_or_create_by(verb: "PUT").id,
-                            event_name: "passwordEntry",
-                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Opera/24.0.1309.0 Safari/537.17").browser,
-                                                 os: UserAgent.parse("Mozilla/5.0 (Linux; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
-                                                 ).id,
-                            display_id: Display.find_or_create_by(width: "9000", height: "9000").id,
-                            ip: "99.99.99.9999"
-                          })
 
     url = Url.find_by(address: "http://turing.io/")
-
-    assert_equal ["POST", "PUT"], Url.all_verbs(url)
+    assert_equal ["POST", "PUT", "POST", "POST", "POST"], Url.all_verbs(url)
   end
 
   def test_can_find_three_most_popular_referrers
-    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
-                            requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 37,
-                            referrer_id: Referrer.find_or_create_by(referred_by:"http://jumpstartlab.com").id,
-                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
-                            event_name: "socialLogin",
-                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").browser,
-                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
-                                                 ).id,
-                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
-                            ip: "63.29.38.211"
-                          })
-
-    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
-                            requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 37,
-                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
-                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
-                            event_name: "socialLogin",
-                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").browser,
-                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
-                                                 ).id,
-                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
-                            ip: "63.29.38.211"
-                          })
-
-    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
-                            requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 37,
-                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
-                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
-                            event_name: "socialLogin",
-                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").browser,
-                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
-                                                 ).id,
-                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
-                            ip: "63.29.38.211"
-                          })
-
-    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
-                            requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 37,
-                            referrer_id: Referrer.find_or_create_by(referred_by:"http://bing.com").id,
-                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
-                            event_name: "socialLogin",
-                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").browser,
-                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
-                                                 ).id,
-                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
-                            ip: "63.29.38.211"
-                          })
 
     url = Url.find_by(address: "http://jumpstartlab.com/")
 
@@ -165,38 +65,12 @@ class UrlTest < Minitest::Spec
   end
 
   def test_can_find_three_most_popular_user_agents
-    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
-                            requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 37,
-                            referrer_id: Referrer.find_or_create_by(referred_by:"http://jumpstartlab.com").id,
-                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
-                            event_name: "socialLogin",
-                            user_id: User.find_or_create_by(browser: UserAgent.parse("Aetscape/5.0 (Macintosh; Intel Mac OS X 10_8_2) Aetscape/537.17 (KHTML, like Gecko) Aetscape/24.0.1309.0 Aetscape/537.17").browser,
-                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
-                                                 ).id,
-                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
-                            ip: "63.29.38.211"
-                          })
-
-    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
-                            requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 37,
-                            referrer_id: Referrer.find_or_create_by(referred_by:"http://jumpstartlab.com").id,
-                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
-                            event_name: "socialLogin",
-                            user_id: User.find_or_create_by(browser: UserAgent.parse("").browser,
-                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
-                                                 ).id,
-                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
-                            ip: "63.29.38.211"
-                          })
-
 
     url = Url.find_by(address: "http://jumpstartlab.com/")
 
     user_agents = Url.popular_user_agents(url)
 
-    assert_equal [["Macintosh", "Chrome"], ["Macintosh", "Mozilla"], ["Macintosh", "Aetscape"]], user_agents
+    assert_equal [["Macintosh", "Chrome"], ["Macintosh", "Aetscape"], ["Macintosh", "Mozilla"]], user_agents
     assert_equal 3, user_agents.count
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -12,7 +12,7 @@ class UserTest < Minitest::Spec
     assert browser.any? { |b| b == "Chrome" }
     assert browser.any? { |b| b == "Safari" }
     assert browser.any? { |b| b == "Safari" }
-    assert_equal ["Chrome", "Safari", "Safari"], browser
+    assert_equal ["Chrome", "Safari", "Safari", "Aetscape", "Mozilla"], browser
   end
 
   def test_user_returns_breakdown_of_os
@@ -24,7 +24,7 @@ class UserTest < Minitest::Spec
     assert os.any? { |b| b == "Macintosh" }
     assert os.any? { |b| b == "Linux" }
     assert os.any? { |b| b == "Windows" }
-    assert_equal ["Macintosh", "Linux", "Windows"], os
+    assert_equal ["Macintosh", "Linux", "Windows", "Macintosh", "Macintosh"], os
   end
 
   def test_user_will_return_one_browser_for_single_payload
@@ -46,7 +46,7 @@ class UserTest < Minitest::Spec
     assert_equal ["Safari"], browser
   end
 
-  def test_user_will_return_empty_strings_for_empty_string_responses
+  def test_user_will_return_mozilla_for_empty_string_responses
     PayloadRequest.create({ url_id: Url.create(address: "http://jumpstartlab.com/").id,
                             requested_at: "2013-02-16 21:38:28 -0700",
                             responded_in: 37,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -79,8 +79,141 @@ module TestHelpers
                             display_id: Display.find_or_create_by(width: "4000", height: "4000").id,
                             ip: "10.00.00.000"
                           })
+    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
+                            requested_at: "2013-02-16 21:38:28 -0700",
+                            responded_in: 37,
+                            referrer_id: Referrer.find_or_create_by(referred_by:"http://jumpstartlab.com").id,
+                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
+                            event_name: "socialLogin",
+                            user_id: User.find_or_create_by(browser: UserAgent.parse("Aetscape/5.0 (Macintosh; Intel Mac OS X 10_8_2) Aetscape/537.17 (KHTML, like Gecko) Aetscape/24.0.1309.0 Aetscape/537.17").browser,
+                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
+                                                 ).id,
+                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
+                            ip: "63.29.38.211"
+                          })
 
+    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
+                            requested_at: "2013-02-16 21:38:28 -0700",
+                            responded_in: 37,
+                            referrer_id: Referrer.find_or_create_by(referred_by:"http://jumpstartlab.com").id,
+                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
+                            event_name: "socialLogin",
+                            user_id: User.find_or_create_by(browser: UserAgent.parse("").browser,
+                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
+                                                 ).id,
+                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
+                            ip: "63.29.38.211"
+                          })
+    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
+                            requested_at: "2013-02-16 21:38:28 -0700",
+                            responded_in: 37,
+                            referrer_id: Referrer.find_or_create_by(referred_by:"http://jumpstartlab.com").id,
+                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
+                            event_name: "socialLogin",
+                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").browser,
+                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
+                                                 ).id,
+                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
+                            ip: "63.29.38.211"
+                          })
 
+    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
+                            requested_at: "2013-02-16 21:38:28 -0700",
+                            responded_in: 37,
+                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
+                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
+                            event_name: "socialLogin",
+                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").browser,
+                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
+                                                 ).id,
+                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
+                            ip: "63.29.38.211"
+                          })
 
-    end
+    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
+                            requested_at: "2013-02-16 21:38:28 -0700",
+                            responded_in: 37,
+                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
+                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
+                            event_name: "socialLogin",
+                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").browser,
+                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
+                                                 ).id,
+                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
+                            ip: "63.29.38.211"
+                          })
+
+    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
+                            requested_at: "2013-02-16 21:38:28 -0700",
+                            responded_in: 37,
+                            referrer_id: Referrer.find_or_create_by(referred_by:"http://bing.com").id,
+                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
+                            event_name: "socialLogin",
+                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").browser,
+                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
+                                                 ).id,
+                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
+                            ip: "63.29.38.211"
+                          })
+    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://turing.io/").id,
+                            requested_at: "2014-02-16 21:38:28 -0700",
+                            responded_in: 100,
+                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
+                            request_type_id: RequestType.find_or_create_by(verb: "PUT").id,
+                            event_name: "passwordEntry",
+                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Opera/24.0.1309.0 Safari/537.17").browser,
+                                                 os: UserAgent.parse("Mozilla/5.0 (Linux; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
+                                                 ).id,
+                            display_id: Display.find_or_create_by(width: "9000", height: "9000").id,
+                            ip: "99.99.99.9999"
+                          })
+    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://turing.io/").id,
+                            requested_at: "2014-02-16 21:38:28 -0700",
+                            responded_in: 100,
+                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
+                            request_type_id: RequestType.find_or_create_by(verb: "POST").id,
+                            event_name: "passwordEntry",
+                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Opera/24.0.1309.0 Safari/537.17").browser,
+                                                 os: UserAgent.parse("Mozilla/5.0 (Linux; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
+                                                 ).id,
+                            display_id: Display.find_or_create_by(width: "9000", height: "9000").id,
+                            ip: "99.99.99.9999"
+                          })
+    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://turing.io/").id,
+                            requested_at: "2014-02-16 21:38:28 -0700",
+                            responded_in: 100,
+                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
+                            request_type_id: RequestType.find_or_create_by(verb: "POST").id,
+                            event_name: "passwordEntry",
+                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Opera/24.0.1309.0 Safari/537.17").browser,
+                                                 os: UserAgent.parse("Mozilla/5.0 (Linux; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
+                                                 ).id,
+                            display_id: Display.find_or_create_by(width: "9000", height: "9000").id,
+                            ip: "99.99.99.9999"
+                          })
+    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://turing.io/").id,
+                            requested_at: "2014-02-16 21:38:28 -0700",
+                            responded_in: 10,
+                            referrer_id: Referrer.find_or_create_by(referred_by:"http://google.com").id,
+                            request_type_id: RequestType.find_or_create_by(verb: "POST").id,
+                            event_name: "passwordEntry",
+                            user_id: User.find_or_create_by(browser: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Opera/24.0.1309.0 Safari/537.17").browser,
+                                                 os: UserAgent.parse("Mozilla/5.0 (Linux; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
+                                                 ).id,
+                            display_id: Display.find_or_create_by(width: "9000", height: "9000").id,
+                            ip: "99.99.99.9999"
+                          })
+    PayloadRequest.create({ url_id: Url.find_or_create_by(address: "http://jumpstartlab.com/").id,
+                            requested_at: "2013-02-16 21:38:28 -0700",
+                            responded_in: 37,
+                            referrer_id: Referrer.find_or_create_by(referred_by:"http://jumpstartlab.com").id,
+                            request_type_id: RequestType.find_or_create_by(verb: "GET").id,
+                            event_name: "socialLogin",
+                            user_id: User.find_or_create_by(browser: UserAgent.parse("Aetscape/5.0 (Macintosh; Intel Mac OS X 10_8_2) Aetscape/537.17 (KHTML, like Gecko) Aetscape/24.0.1309.0 Aetscape/537.17").browser,
+                                                 os: UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17").platform
+                                                 ).id,
+                            display_id: Display.find_or_create_by(width: "1920", height: "1280").id,
+                            ip: "63.29.38.211"
+                          })
+  end
 end


### PR DESCRIPTION
all payload creation removed from url_test and moved into TestHelpers.create_payloads

arithmetic calculations updated in payload_request_test

user_test still has two payload creations, but these seem appropriate for their respective tests

**_important**_
the following methods return duplicate objects. iteration 2 spec asks for a "breakdown" for userAgent info, and all verbs for requested url (i.e. unsure of whether we will need a count in all cases). This seems to be a design decision that later iterations may dictate.

Url.all_verbs :: url_test line 55

User.browser_breakdown :: user_test line 15

User.os_breakdown :: user_test line 21
